### PR TITLE
Replaced btrfdeck with SteamOS Btrfs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,9 +510,7 @@ Emulation Station Front End
  ## Btrfs on Steam Deck
  [Back to the Top](https://github.com/mikeroyal/Steam-Deck-Guide#table-of-contents)
  
- **Warning: This project is still experimental and buggy so this is only recommended for advanced users!**
- 
- [Btrfdeck](https://github.com/Trevo525/btrfdeck) is a project that will help get you from using ext4 on your Steam Deck's microSD card, to [Btrfs](https://btrfs.wiki.kernel.org/). 
+ [SteamOS Btrfs](https://gitlab.com/popsulfr/steamos-btrfs/) is a project that will help get you from using ext4 on your Steam Deck's microSD card or home directory, to [Btrfs](https://btrfs.wiki.kernel.org/). 
  
  <p align="center">
  <img src="https://user-images.githubusercontent.com/45159366/172273657-f184233d-56d8-429b-9a63-d8a2b8e7412b.png">


### PR DESCRIPTION
Hello!

I am the person who made [Btrfdeck](https://github.com/Trevo525/btrfdeck). I appreciate you linking to my project. However, I have archived it and it is no longer supported. I have been using [SteamOS Btrfs](https://gitlab.com/popsulfr/steamos-btrfs/). So I figured I'd make a PR so that you can link to the actively developed project.