### PR TITLE
Fixed Anker USB Hubs Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ PS 5  DualSense™ Controller
 
 [Anker PowerCore Battery Bank](https://www.amazon.com/Anker-Portable-PowerCore-Essential-Compatible/dp/B08LG2X98F)
 
-[Anker USB C Hub](https://www.anker.com/products/114/142/usb-c-hubs)
+[Anker USB C Hub](https://www.anker.com/collections/hubs)
 
 
 ## Steam Deck Development


### PR DESCRIPTION
The link to anker hubs was broken, so it now point to anker's USB hubs page.