### PR TITLE
Changed Fedora Name and Removed FSR 2 Release Date

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ PS 5  DualSense™ Controller
 
 [AMD FidelityFX Super Resolution (FSR)](https://www.amd.com/en/technologies/radeon-software-fidelityfx) is an open source, high-quality solution for producing high resolution frames from lower resolution inputs. FSR enables “practical performance” for costly render operations, such as hardware ray tracing for the AMD RDNA™ and AMD RDNA™ 2 architectures.
 
-[AMD FidelityFX Super Resolution (FSR) 2.0](https://www.amd.com/en/press-releases/2022-03-17-introducing-amd-software-adrenalin-edition-2022-release-and-amd) is an open source, high-quality solution for producing high resolution frames from lower resolution inputs. It uses temporal data and optimized anti-aliasing to boost framerates in supported games while delivering similar or better image quality than native resolution without requiring dedicated machine learning hardware. AMD FSR 2.0 will be available some time Q2 2022.
+[AMD FidelityFX Super Resolution (FSR) 2.0](https://www.amd.com/en/press-releases/2022-03-17-introducing-amd-software-adrenalin-edition-2022-release-and-amd) is an open source, high-quality solution for producing high resolution frames from lower resolution inputs. It uses temporal data and optimized anti-aliasing to boost framerates in supported games while delivering similar or better image quality than native resolution without requiring dedicated machine learning hardware.
 
 [MangoHud](https://github.com/flightlessmango/MangoHud) is a Vulkan and OpenGL overlay for monitoring FPS, temperatures, CPU/GPU load and more.
 
@@ -420,7 +420,7 @@ ArcoLinux Desktop
 ArchTitus Desktop
 </h3>
 
-**[Fedora 35](https://getfedora.org/)**
+**[Fedora Linux](https://getfedora.org/)**
 
 <h3 align="center">
  <img src="https://user-images.githubusercontent.com/45159366/142779592-8b70c81e-ac10-4bb3-91b5-efe25fa9afb4.png">


### PR DESCRIPTION
Changes the Fedora name from Fedora 35 to Fedora Linux, and removes the release schedule for FSR 2.0 (since it has already been released).

Apologies for making two pull requests - I accidentally deleted the fork for the other one (through the back button and my browser filling passwords before me realising) so I had to make a new one.